### PR TITLE
Add clientId textfield when creating a new client

### DIFF
--- a/src/components/ClientForm/index.jsx
+++ b/src/components/ClientForm/index.jsx
@@ -143,7 +143,7 @@ export default class ClientForm extends Component {
               />
             </FormGroup>
           </ListItem>
-          {isNewClient ? (
+          {isNewClient && (
             <ListItem>
               <TextField
                 label="Client ID"
@@ -153,7 +153,7 @@ export default class ClientForm extends Component {
                 value={clientId}
               />
             </ListItem>
-          ) : null}
+          )}
           {client && (
             <Fragment>
               <ListItem>

--- a/src/components/ClientForm/index.jsx
+++ b/src/components/ClientForm/index.jsx
@@ -143,6 +143,17 @@ export default class ClientForm extends Component {
               />
             </FormGroup>
           </ListItem>
+          {isNewClient ? (
+            <ListItem>
+              <TextField
+                label="Client ID"
+                name="clientId"
+                onChange={this.handleInputChange}
+                fullWidth
+                value={clientId}
+              />
+            </ListItem>
+          ) : null}
           {client && (
             <Fragment>
               <ListItem>

--- a/src/views/Clients/ViewClient/index.jsx
+++ b/src/views/Clients/ViewClient/index.jsx
@@ -22,7 +22,7 @@ export default class ViewClient extends Component {
 
     return (
       <Dashboard
-        title="Client"
+        title={isNewClient ? 'Create Client' : 'Client'}
         user={user}
         onSignIn={onSignIn}
         onSignOut={onSignOut}>


### PR DESCRIPTION
The client ID field should be editable when creating a new client but not when editing an existing client. This commit implements this logic.