### PR TITLE
Fixes Sign Modal (Resolves #98)

### DIFF
--- a/src/components/Dashboard/UserMenu.jsx
+++ b/src/components/Dashboard/UserMenu.jsx
@@ -113,7 +113,7 @@ export default class UserMenu extends Component {
           id="user-menu"
           anchorEl={anchorEl}
           open={Boolean(anchorEl)}
-          onClose={this.handleClose}>
+          onClose={this.handleMenuClose}>
           <MenuItem onClick={this.handleMenuClose}>Manage Credentials</MenuItem>
           <MenuItem onClick={this.handleClickSignOut}>Sign Out</MenuItem>
         </Menu>


### PR DESCRIPTION
The Sign modal will close on clicking anywhere outside the modal window.
![screen shot 2018-09-04 at 1 16 33 pm](https://user-images.githubusercontent.com/24795489/45017456-46b06f00-b045-11e8-8e09-c6344aaea302.png)
