### PR TITLE
Add client view initial search content #158

### DIFF
--- a/src/views/Clients/ViewClients/index.jsx
+++ b/src/views/Clients/ViewClients/index.jsx
@@ -13,8 +13,10 @@ import Button from '../../../components/Button';
 import ClientsTable from '../../../components/ClientsTable';
 import { VIEW_CLIENTS_PAGE_SIZE } from '../../../utils/constants';
 import clientsQuery from './clients.graphql';
+import { withAuth } from '../../../utils/Auth';
 
 @hot(module)
+@withAuth
 @graphql(clientsQuery, {
   options: () => ({
     variables: {
@@ -30,8 +32,11 @@ import clientsQuery from './clients.graphql';
   },
 }))
 export default class ViewWorker extends PureComponent {
+  componentDidMount() {
+    this.handleClientSearchSubmit();
+  }
   state = {
-    clientSearch: '',
+    clientSearch: this.props.user.credentials.clientId,
   };
 
   handlePageChange = ({ cursor, previousCursor }) => {
@@ -78,7 +83,9 @@ export default class ViewWorker extends PureComponent {
   };
 
   handleClientSearchSubmit = e => {
-    e.preventDefault();
+    if (e) {
+      e.preventDefault();
+    }
 
     const {
       data: { refetch },


### PR DESCRIPTION
Set client id as default search in Authorization/Clients

Added client id as default state in Search component along with initial search query for the specified id on page load.

Fixes #158, however users are now unable to retrieve a 'full' default clients view (e.g. expected search query with '' to retrieve full list of clients does not work) 