### PR TITLE
'Source' link icon is same size as  other icons

### DIFF
--- a/src/components/TaskDetailsCard/index.jsx
+++ b/src/components/TaskDetailsCard/index.jsx
@@ -112,7 +112,7 @@ export default class TaskDetailsCard extends Component {
                   primary="Source"
                   secondary={task.metadata.source}
                 />
-                {isExternal ? <OpenInNewIcon /> : <LinkIcon />}
+                <OpenInNewIcon />
               </ListItem>
               <ListItem
                 button


### PR DESCRIPTION
{isExternal ? <OpenInNewIcon /> : <LinkIcon />}
this seemed as a feature , rather than a bug. 
But this is what was producing a smaller icon.
 