### PR TITLE
Add `appIcon` class to the `HelpIcon`

### DIFF
--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -244,7 +244,7 @@ export default class Dashboard extends Component {
                 <IconButton
                   onClick={this.handleHelpViewToggle}
                   className={classes.appBarButton}>
-                  <HelpIcon />
+                  <HelpIcon className={classes.appIcon} />
                 </IconButton>
               </Tooltip>
             )}


### PR DESCRIPTION
Since we want the `fill` value for the `HelpIcon` to always remain consistent with the `LightBulbOn`/`LightBulbOnOutline` icons we should use the same class which provides the same `fill` value.

This is a fix related to https://github.com/taskcluster/taskcluster-web/issues/161