### PR TITLE
Prevented passing of auth functions as props to Button component.

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -53,16 +53,11 @@ export default class Button extends Component {
       user,
       onClick,
       track,
+      onAuthorize,
+      onUnauthorize,
       ...props
     } = this.props;
     const isDisabled = (requiresAuth && !user) || disabled;
-
-    /*
-     these function props are not relevant to button component 
-     and create console warning.
-    */
-    delete props.onAuthorize;
-    delete props.onUnauthorize;
 
     return (
       <MuiButton

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -57,6 +57,13 @@ export default class Button extends Component {
     } = this.props;
     const isDisabled = (requiresAuth && !user) || disabled;
 
+    /*
+     these function props are not relevant to button component 
+     and create console warning.
+    */
+    delete props.onAuthorize;
+    delete props.onUnauthorize;
+
     return (
       <MuiButton
         onClick={this.handleButtonClick}


### PR DESCRIPTION
These function props were probably reaching native html attributes
and while being ignored by browser, warnings were getting generated.

fixes #204 