### PR TITLE
When signing out - clear the Apollo client cache

### DIFF
--- a/src/components/Dashboard/UserMenu.jsx
+++ b/src/components/Dashboard/UserMenu.jsx
@@ -64,7 +64,7 @@ export default class UserMenu extends Component {
     this.handleMenuClose();
     // Since Apollo caches query results, it’s important to get rid of them
     // when the login state changes.
-    await this.props.client.resetStore();
+    await this.props.client.clearStore();
     this.props.onUnauthorize();
   };
 

--- a/src/components/Dashboard/UserMenu.jsx
+++ b/src/components/Dashboard/UserMenu.jsx
@@ -46,6 +46,9 @@ export default class UserMenu extends Component {
   handleClickSignOut = () => {
     this.handleMenuClose();
     this.props.onUnauthorize();
+    // Since Apollo caches query results, it’s important to get rid of them
+    // when the login state changes.
+    this.props.client.clearStore();
   };
 
   handleMenuClick = e => {
@@ -58,14 +61,6 @@ export default class UserMenu extends Component {
 
   handleSignInDialogClose = () => {
     this.setState({ signInDialogOpen: false });
-  };
-
-  handleClickSignOut = async () => {
-    this.handleMenuClose();
-    // Since Apollo caches query results, it’s important to get rid of them
-    // when the login state changes.
-    await this.props.client.clearStore();
-    this.props.onUnauthorize();
   };
 
   handleSignInDialogOpen = () => {


### PR DESCRIPTION
RE: https://github.com/taskcluster/taskcluster-web/issues/226

### What does this PR change?
This replaces [`ApolloClient#resetStore`](https://www.apollographql.com/docs/react/api/apollo-client.html#ApolloClient.resetStore) with [`ApolloClient#clearStore`](https://www.apollographql.com/docs/react/api/apollo-client.html#ApolloClient.clearStore) when signing out.

### Why is this important?
When we were calling `ApolloClient#resetStore` - all active queries would be refetched, and if one of those queries returned a response that wasn't parsable as JSON, ApolloClient would throw an error resulting in an incomplete sign out process.

By using `ApolloClient#clearStore`, the store is cleared, but no queries are refetched which allows the sign out process to complete.