### PR TITLE
Remove build command from netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,3 @@
-[build]
-  command = "yarn build"
-  publish = "build"
-
 [build.environment]
   YARN_FLAGS = "--frozen-lockfile"
   YARN_VERSION = "1.10.1"


### PR DESCRIPTION
We have two different site configurations (taskcluster-web and
taskcluster-web-styleguide) that use this repo. In order to use
different build and publish commands, we will have to rely on manually
specifying the commands from the UI.