### PR TITLE
UX tweaks to task inspector

### DIFF
--- a/src/components/TaskDetailsCard/index.jsx
+++ b/src/components/TaskDetailsCard/index.jsx
@@ -10,7 +10,6 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
 import Collapse from '@material-ui/core/Collapse';
-import Chip from '@material-ui/core/Chip';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -43,6 +42,7 @@ import urls from '../../utils/urls';
   sourceHeadline: {
     textOverflow: 'ellipsis',
     overflowX: 'hidden',
+    whiteSpace: 'nowrap',
   },
   sourceHeadlineText: {
     flex: 1,
@@ -61,10 +61,6 @@ import urls from '../../utils/urls';
     '& button, & a': {
       ...theme.mixins.listItemButton,
     },
-  },
-  tag: {
-    height: theme.spacing.unit * 3,
-    margin: `${theme.spacing.unit}px ${theme.spacing.unit}px 0 0`,
   },
   unorderedList: {
     ...theme.mixins.unorderedList,
@@ -121,7 +117,6 @@ export default class TaskDetailsCard extends Component {
     const { classes, task, dependentTasks } = this.props;
     const { showPayload, showExtra, showMore } = this.state;
     const isExternal = task.metadata.source.startsWith('https://');
-    const tags = Object.entries(task.tags);
     const payload = deepSortObject(task.payload);
 
     return (
@@ -199,6 +194,12 @@ export default class TaskDetailsCard extends Component {
               </CopyToClipboard>
               <ListItem>
                 <ListItemText
+                  primary="Provisioner"
+                  secondary={task.provisionerId}
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText
                   primary="Worker Type"
                   secondary={task.workerType}
                 />
@@ -220,60 +221,32 @@ export default class TaskDetailsCard extends Component {
                   </IconButton>
                 </ListItemSecondaryAction>
               </ListItem>
-
-              <Fragment>
-                <ListItem>
-                  {tags.length ? (
-                    <ListItemText
-                      primary="Tags"
-                      secondary={tags.map(([key, value]) => (
-                        <Chip
-                          key={key}
-                          className={classes.tag}
-                          label={
-                            <Fragment>
-                              {key}
-                              :&nbsp;&nbsp;
-                              <em>{value}</em>
-                            </Fragment>
-                          }
-                        />
-                      ))}
-                    />
-                  ) : (
-                    <ListItemText primary="Tags" secondary="n/a" />
-                  )}
-                </ListItem>
-              </Fragment>
-              <ListItem>
-                <ListItemText
-                  primary="Requires"
-                  secondary={
-                    <Fragment>
-                      This task will be scheduled when
-                      <strong>
-                        <em> dependencies </em>
-                      </strong>
-                      are
-                      {task.requires === 'ALL_COMPLETED' ? (
-                        <Fragment>
-                          &nbsp;
-                          <code>all-completed</code> successfully.
-                        </Fragment>
-                      ) : (
-                        <Fragment>
-                          &nbsp;
-                          <code>all-resolved</code> with any resolution.
-                        </Fragment>
-                      )}
-                    </Fragment>
-                  }
-                />
-              </ListItem>
               {dependentTasks && dependentTasks.length ? (
                 <Fragment>
                   <ListItem>
-                    <ListItemText primary="Dependencies" />
+                    <ListItemText
+                      primary="Dependencies"
+                      secondary={
+                        <Fragment>
+                          This task will be scheduled when
+                          <strong>
+                            <em> dependencies </em>
+                          </strong>
+                          are
+                          {task.requires === 'ALL_COMPLETED' ? (
+                            <Fragment>
+                              &nbsp;
+                              <code>all-completed</code> successfully.
+                            </Fragment>
+                          ) : (
+                            <Fragment>
+                              &nbsp;
+                              <code>all-resolved</code> with any resolution.
+                            </Fragment>
+                          )}
+                        </Fragment>
+                      }
+                    />
                   </ListItem>
                   <List dense disablePadding>
                     {dependentTasks.map(task => (
@@ -375,12 +348,6 @@ export default class TaskDetailsCard extends Component {
             </List>
             <Collapse in={showMore} timeout="auto">
               <List>
-                <ListItem>
-                  <ListItemText
-                    primary="Provisioner"
-                    secondary={task.provisionerId}
-                  />
-                </ListItem>
                 <ListItem>
                   <ListItemText
                     primary="Retries Left"

--- a/src/views/Tasks/ViewTask/index.jsx
+++ b/src/views/Tasks/ViewTask/index.jsx
@@ -79,8 +79,8 @@ const getCachesFromTask = task =>
   divider: {
     margin: `${theme.spacing.triple}px 0`,
   },
-  owner: {
-    marginTop: theme.spacing.unit,
+  tag: {
+    margin: `${theme.spacing.unit}px ${theme.spacing.unit}px 0 0`,
   },
   dialogListItem: {
     paddingTop: 0,
@@ -620,6 +620,11 @@ export default class ViewTask extends Component {
       actionLoading,
       dialogError,
     } = this.state;
+    let tags;
+
+    if (task) {
+      tags = Object.entries(task.tags);
+    }
 
     return (
       <Dashboard
@@ -637,7 +642,7 @@ export default class ViewTask extends Component {
               <Markdown>{task.metadata.description}</Markdown>
             </Typography>
             <Chip
-              className={classes.owner}
+              className={classes.tag}
               label={
                 <Fragment>
                   owned by:&nbsp;&nbsp;
@@ -645,6 +650,19 @@ export default class ViewTask extends Component {
                 </Fragment>
               }
             />
+            {tags.map(([key, value]) => (
+              <Chip
+                className={classes.tag}
+                key={key}
+                label={
+                  <Fragment>
+                    {key}
+                    :&nbsp;&nbsp;
+                    <em>{value}</em>
+                  </Fragment>
+                }
+              />
+            ))}
             <Divider className={classes.divider} />
             <Grid container spacing={24}>
               <Grid item xs={12} md={6}>


### PR DESCRIPTION
1. Make requires and dependencies as one field
2. Group the provisioner and worker type fields
3. Reposition tags to be beside the "owned by" pill

Relates to https://github.com/taskcluster/taskcluster-web/issues/252.