### PR TITLE
Add secondary color as default for SpeedDialAction

### DIFF
--- a/src/components/ClientForm/index.jsx
+++ b/src/components/ClientForm/index.jsx
@@ -345,7 +345,7 @@ export default class ClientForm extends Component {
               tooltipOpen
               icon={<ContentSaveIcon className={classes.saveIcon} />}
               onClick={this.handleSaveClient}
-              classes={{ button: classes.saveIcon }}
+              className={classes.saveIcon}
               tooltipTitle="Save"
               ButtonProps={{ disabled: loading }}
             />
@@ -354,7 +354,7 @@ export default class ClientForm extends Component {
               tooltipOpen
               icon={<DeleteIcon />}
               onClick={this.handleDeleteClient}
-              classes={{ button: classes.deleteIcon }}
+              className={classes.deleteIcon}
               tooltipTitle="Delete"
               ButtonProps={{ disabled: loading }}
             />
@@ -379,7 +379,6 @@ export default class ClientForm extends Component {
               onClick={this.handleResetAccessToken}
               tooltipTitle="Reset Access Token"
               ButtonProps={{
-                color: 'secondary',
                 disabled: loading,
               }}
             />

--- a/src/components/HookForm/index.jsx
+++ b/src/components/HookForm/index.jsx
@@ -615,7 +615,6 @@ export default class HookForm extends Component {
               onClick={this.handleUpdateHook}
               tooltipTitle="Save Hook"
               ButtonProps={{
-                color: 'secondary',
                 disabled: !this.validHook() || actionLoading,
               }}
             />
@@ -624,7 +623,7 @@ export default class HookForm extends Component {
               tooltipOpen
               icon={<DeleteIcon />}
               onClick={this.handleDeleteHook}
-              classes={{ button: classes.deleteIcon }}
+              className={classes.deleteIcon}
               ButtonProps={{
                 disabled: actionLoading,
               }}
@@ -635,7 +634,7 @@ export default class HookForm extends Component {
               tooltipOpen
               icon={<FlashIcon />}
               onClick={this.handleTriggerHookClick}
-              classes={{ button: classes.successIcon }}
+              className={classes.successIcon}
               ButtonProps={{
                 disabled: !this.validHook() || actionLoading,
               }}

--- a/src/components/RoleForm/index.jsx
+++ b/src/components/RoleForm/index.jsx
@@ -226,7 +226,7 @@ export default class RoleForm extends Component {
               tooltipOpen
               icon={<ContentSaveIcon />}
               onClick={this.handleSaveRole}
-              classes={{ button: classes.saveIcon }}
+              className={classes.saveIcon}
               tooltipTitle="Save"
               ButtonProps={{ disabled: loading }}
             />
@@ -236,7 +236,7 @@ export default class RoleForm extends Component {
               icon={<DeleteIcon />}
               onClick={this.handleDeleteRole}
               tooltipTitle="Delete"
-              classes={{ button: classes.deleteIcon }}
+              className={classes.deleteIcon}
               ButtonProps={{
                 disabled: loading,
               }}

--- a/src/components/SecretForm/index.jsx
+++ b/src/components/SecretForm/index.jsx
@@ -192,7 +192,7 @@ export default class SecretForm extends Component {
               tooltipOpen
               icon={<ContentSaveIcon />}
               onClick={this.handleSaveSecret}
-              classes={{ button: classes.saveIcon }}
+              className={classes.saveIcon}
               tooltipTitle="Save Secret"
               ButtonProps={{
                 disabled: loading || !this.validSecret(),
@@ -203,7 +203,7 @@ export default class SecretForm extends Component {
               tooltipOpen
               icon={<DeleteIcon />}
               onClick={this.handleDeleteSecret}
-              classes={{ button: classes.deleteIcon }}
+              className={classes.deleteIcon}
               tooltipTitle="Delete Secret"
               ButtonProps={{
                 disabled: loading,

--- a/src/components/SpeedDialAction/index.jsx
+++ b/src/components/SpeedDialAction/index.jsx
@@ -1,24 +1,36 @@
 import React, { Component } from 'react';
+import classNames from 'classnames';
+import { withStyles } from '@material-ui/core/styles';
 import MuiSpeedDialAction from '@material-ui/lab/SpeedDialAction';
-import { bool } from 'prop-types';
+import { string, bool } from 'prop-types';
 import { withAuth } from '../../utils/Auth';
 
 @withAuth
+@withStyles(theme => ({
+  secondaryIcon: {
+    ...theme.mixins.secondaryIcon,
+  },
+}))
 /**
  * A Material UI SpeedDialAction augmented with application specific props.
  */
 export default class SpeedDialAction extends Component {
   static defaultProps = {
+    className: null,
     requiresAuth: false,
   };
 
   static propTypes = {
+    /** The CSS class name of the wrapper element */
+    className: string,
     /** If true, the button will be disabled if the user is not authenticated */
     requiresAuth: bool,
   };
 
   render() {
     const {
+      classes,
+      className,
       requiresAuth,
       ButtonProps,
       user,
@@ -32,6 +44,12 @@ export default class SpeedDialAction extends Component {
       ...(disabled ? { disabled: true } : {}),
     };
 
-    return <MuiSpeedDialAction ButtonProps={buttonProps} {...props} />;
+    return (
+      <MuiSpeedDialAction
+        className={classNames(classes.secondaryIcon, className)}
+        ButtonProps={buttonProps}
+        {...props}
+      />
+    );
   }
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -140,6 +140,15 @@ const createTheme = isDarkTheme => ({
         fill: 'white',
       },
     },
+    secondaryIcon: {
+      backgroundColor: THEME.SECONDARY,
+      '&:hover': {
+        backgroundColor: fade(THEME.SECONDARY, 0.9),
+      },
+      '& svg': {
+        backgroundColor: 'transparent',
+      },
+    },
     successIcon: {
       backgroundColor: success.main,
       '&:hover': {

--- a/src/views/AwsProvisioner/ViewWorkerTypeDefinition/index.jsx
+++ b/src/views/AwsProvisioner/ViewWorkerTypeDefinition/index.jsx
@@ -277,7 +277,7 @@ export default class ViewWorkerTypeDefinition extends Component {
             <SpeedDialAction
               requiresAuth
               icon={<ContentSaveIcon />}
-              classes={{ button: classes.successIcon }}
+              className={classes.successIcon}
               tooltipTitle="Update Worker Type"
               onClick={this.handleUpdateWorkerType}
               ButtonProps={{ disabled: invalidDefinition || actionLoading }}
@@ -286,7 +286,7 @@ export default class ViewWorkerTypeDefinition extends Component {
               requiresAuth
               icon={<DeleteIcon />}
               tooltipTitle="Delete Worker Type"
-              classes={{ button: classes.deleteIcon }}
+              className={classes.deleteIcon}
               onClick={this.handleDeleteWorkerType}
               ButtonProps={{ disabled: actionLoading }}
             />

--- a/src/views/AwsProvisioner/ViewWorkerTypes/index.jsx
+++ b/src/views/AwsProvisioner/ViewWorkerTypes/index.jsx
@@ -81,23 +81,20 @@ export default class ViewRoles extends Component {
               icon={<PlusIcon />}
               tooltipTitle="Create Worker Type"
               onClick={this.handleCreate}
-              ButtonProps={{ color: 'secondary' }}
             />
             <SpeedDialAction
               tooltipOpen
               icon={<AlertCircleOutlineIcon />}
               tooltipTitle="Recent Provisioning Errors"
-              classes={{ button: classes.alertIcon }}
+              className={classes.alertIcon}
               onClick={this.handleRecentErrorsClick}
-              ButtonProps={{ color: 'secondary' }}
             />
             <SpeedDialAction
               tooltipOpen
               icon={<HeartPulseIcon />}
               tooltipTitle="Health"
-              classes={{ button: classes.heartIcon }}
+              className={classes.heartIcon}
               onClick={this.handleHealthClick}
-              ButtonProps={{ color: 'secondary' }}
             />
           </SpeedDial>
         </Fragment>

--- a/src/views/Provisioners/ViewWorker/index.jsx
+++ b/src/views/Provisioners/ViewWorker/index.jsx
@@ -3,9 +3,9 @@ import React, { Component, Fragment } from 'react';
 import { graphql, withApollo } from 'react-apollo';
 import { format, addYears, isAfter } from 'date-fns';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
-import HammerIcon from 'mdi-react/HammerIcon';
 import TextField from '@material-ui/core/TextField';
 import HomeLockIcon from 'mdi-react/HomeLockIcon';
+import HammerIcon from 'mdi-react/HammerIcon';
 import HomeLockOpenIcon from 'mdi-react/HomeLockOpenIcon';
 import Dashboard from '../../../components/Dashboard';
 import WorkerDetailsCard from '../../../components/WorkerDetailsCard';
@@ -165,7 +165,6 @@ export default class ViewWorker extends Component {
                   }
                   onClick={this.handleDialogOpen}
                   ButtonProps={{
-                    color: 'secondary',
                     disabled: actionLoading,
                   }}
                 />
@@ -177,7 +176,6 @@ export default class ViewWorker extends Component {
                     icon={<HammerIcon />}
                     onClick={() => this.handleActionDialogOpen(action)}
                     ButtonProps={{
-                      color: 'secondary',
                       disabled: actionLoading,
                     }}
                     tooltipTitle={action.title}

--- a/src/views/Provisioners/ViewWorkers/index.jsx
+++ b/src/views/Provisioners/ViewWorkers/index.jsx
@@ -196,7 +196,6 @@ export default class ViewWorkers extends Component {
                         tooltipOpen
                         key={action.title}
                         ButtonProps={{
-                          color: 'secondary',
                           disabled: actionLoading,
                         }}
                         icon={<HammerIcon />}

--- a/src/views/PulseMessages/index.jsx
+++ b/src/views/PulseMessages/index.jsx
@@ -375,7 +375,7 @@ export default class PulseMessages extends Component {
                 tooltipOpen
                 icon={<StopIcon />}
                 onClick={this.handleStopListening}
-                classes={{ button: classes.stopIcon }}
+                className={classes.stopIcon}
                 tooltipTitle="Stop Listening"
               />
             ) : (
@@ -383,7 +383,7 @@ export default class PulseMessages extends Component {
                 tooltipOpen
                 icon={<PlayIcon />}
                 onClick={this.handleStartListening}
-                classes={{ button: classes.playIcon }}
+                className={classes.playIcon}
                 tooltipTitle="Start Listening"
                 ButtonProps={{ disabled: !bindings.length }}
               />
@@ -393,7 +393,7 @@ export default class PulseMessages extends Component {
               icon={<DownloadIcon />}
               tooltipTitle="Download Messages"
               onClick={this.handleDownloadMessagesClick}
-              ButtonProps={{ color: 'secondary', disabled: !messages[0] }}
+              ButtonProps={{ disabled: !messages[0] }}
             />
           </SpeedDial>
           <Drawer

--- a/src/views/Tasks/CreateTask/index.jsx
+++ b/src/views/Tasks/CreateTask/index.jsx
@@ -302,9 +302,6 @@ export default class CreateTask extends Component {
                   icon={<RotateLeftIcon />}
                   onClick={this.handleResetEditor}
                   tooltipTitle="Reset Editor"
-                  ButtonProps={{
-                    color: 'secondary',
-                  }}
                 />
                 <SpeedDialAction
                   tooltipOpen
@@ -312,7 +309,6 @@ export default class CreateTask extends Component {
                   onClick={this.handleUpdateTimestamps}
                   tooltipTitle="Update Timestamps"
                   ButtonProps={{
-                    color: 'secondary',
                     disabled: !task || invalid,
                   }}
                 />

--- a/src/views/Tasks/TaskGroup/index.jsx
+++ b/src/views/Tasks/TaskGroup/index.jsx
@@ -5,7 +5,6 @@ import dotProp from 'dot-prop-immutable';
 import { isEmpty } from 'ramda';
 import jsonSchemaDefaults from 'json-schema-defaults';
 import { safeDump } from 'js-yaml';
-import { withStyles } from '@material-ui/core/styles';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import HammerIcon from 'mdi-react/HammerIcon';
 import SpeedDial from '../../../components/SpeedDial';
@@ -41,19 +40,6 @@ let previousCursor;
 
 @hot(module)
 @withApollo
-@withStyles(theme => ({
-  code: {
-    maxHeight: '70vh',
-    margin: 0,
-  },
-  codeEditor: {
-    overflow: 'auto',
-    maxHeight: '70vh',
-  },
-  description: {
-    marginBottom: theme.spacing.triple,
-  },
-}))
 @graphql(taskGroupQuery, {
   options: props => ({
     pollInterval: TASK_GROUP_POLLING_INTERVAL,
@@ -347,7 +333,6 @@ export default class TaskGroup extends Component {
                 key={action.title}
                 ButtonProps={{
                   name: action.name,
-                  color: 'primary',
                   disabled: actionLoading,
                 }}
                 icon={<HammerIcon />}

--- a/src/views/Tasks/ViewTask/index.jsx
+++ b/src/views/Tasks/ViewTask/index.jsx
@@ -689,7 +689,6 @@ export default class ViewTask extends Component {
                   requiresAuth
                   tooltipOpen
                   ButtonProps={{
-                    color: 'secondary',
                     disabled: actionLoading,
                   }}
                   icon={<ClockOutlineIcon />}
@@ -702,7 +701,6 @@ export default class ViewTask extends Component {
                   requiresAuth
                   tooltipOpen
                   ButtonProps={{
-                    color: 'secondary',
                     disabled: actionLoading,
                   }}
                   icon={<FlashIcon />}
@@ -714,7 +712,6 @@ export default class ViewTask extends Component {
                 requiresAuth
                 tooltipOpen
                 ButtonProps={{
-                  color: 'secondary',
                   disabled: actionLoading,
                 }}
                 icon={<PencilIcon />}
@@ -726,7 +723,6 @@ export default class ViewTask extends Component {
                   requiresAuth
                   tooltipOpen
                   ButtonProps={{
-                    color: 'secondary',
                     disabled: actionLoading,
                   }}
                   icon={<ConsoleLineIcon />}
@@ -743,7 +739,6 @@ export default class ViewTask extends Component {
                     key={action.title}
                     ButtonProps={{
                       name: action.name,
-                      color: 'primary',
                       disabled: actionLoading,
                     }}
                     icon={this.renderActionIcon(action)}


### PR DESCRIPTION
SpeedDialAction is not a feature complete component (ie., `@material-ui/labl`), and `ButtonProps={{ color: 'secondary' }}` don't seem to work. To add color, we would need to add a class.