### PR TITLE
Allow empty description in a hook

### DIFF
--- a/src/components/HookForm/index.jsx
+++ b/src/components/HookForm/index.jsx
@@ -324,17 +324,9 @@ export default class HookForm extends Component {
   };
 
   validHook = () => {
-    const {
-      name,
-      description,
-      owner,
-      taskValidJson,
-      triggerSchemaValidJson,
-    } = this.state;
+    const { name, owner, taskValidJson, triggerSchemaValidJson } = this.state;
 
-    return (
-      name && description && owner && taskValidJson && triggerSchemaValidJson
-    );
+    return name && owner && taskValidJson && triggerSchemaValidJson;
   };
 
   render() {


### PR DESCRIPTION
This is a similar change to https://github.com/taskcluster/taskcluster-tools/pull/576. A hook description is required however an empty string is considered valid.