### PR TITLE
Add helperText in Client Scope

### DIFF
--- a/src/components/ClientForm/index.jsx
+++ b/src/components/ClientForm/index.jsx
@@ -278,6 +278,7 @@ export default class ClientForm extends Component {
             <TextField
               label="Scopes"
               name="scopeText"
+              helperText="1 scope per line"
               onChange={this.handleInputChange}
               fullWidth
               multiline


### PR DESCRIPTION
helperText `1 scope per line` added in Scope TextField

Fix #354 