### PR TITLE
[Hooks] Make sure the owner field is an email

### DIFF
--- a/src/components/HookForm/index.jsx
+++ b/src/components/HookForm/index.jsx
@@ -168,6 +168,12 @@ export default class HookForm extends Component {
       scheduleTextField: '',
       taskValidJson: true,
       triggerSchemaValidJson: true,
+      validation: {
+        owner:  {
+          error: false,
+          message: "",
+        },
+      }
     };
   }
 
@@ -344,10 +350,18 @@ export default class HookForm extends Component {
       hook: assocPath(['metadata', 'name'], e.target.value, this.state.hook),
     });
 
-  handleOwnerChange = e =>
+  handleOwnerChange = e =>{
+    debugger;
     this.setState({
       hook: assocPath(['metadata', 'owner'], e.target.value, this.state.hook),
-    });
+      validation:{
+        owner: {
+          error: !e.currentTarget.validity.valid,
+          message: e.currentTarget.validationMessage,
+        },
+      },
+    })
+  };
 
   handleDescriptionChange = e =>
     this.setState({
@@ -375,6 +389,7 @@ export default class HookForm extends Component {
       triggerSchemaInput,
       triggerContextInput,
       hook,
+      validation,
     } = this.state;
     /* eslint-disable-next-line no-underscore-dangle */
     const lastFireTypeName = !isNewHook && hook.status.lastFire.__typename;
@@ -434,9 +449,12 @@ export default class HookForm extends Component {
           </ListItem>
           <ListItem>
             <TextField
+              error = {validation.owner.error}
               required
               label="Owner Email"
               name="owner"
+              type="email"
+              helperText={validation.owner.message}
               onChange={this.handleOwnerChange}
               fullWidth
               value={hook.metadata.owner}

--- a/src/components/HookForm/index.jsx
+++ b/src/components/HookForm/index.jsx
@@ -168,12 +168,7 @@ export default class HookForm extends Component {
       scheduleTextField: '',
       taskValidJson: true,
       triggerSchemaValidJson: true,
-      validation: {
-        owner:  {
-          error: false,
-          message: "",
-        },
-      }
+      validation: {},
     };
   }
 
@@ -325,11 +320,17 @@ export default class HookForm extends Component {
   };
 
   validHook = () => {
-    const { hook, taskValidJson, triggerSchemaValidJson } = this.state;
+    const {
+      hook,
+      taskValidJson,
+      triggerSchemaValidJson,
+      validation,
+    } = this.state;
 
     return (
       hook.metadata.name &&
       hook.metadata.owner &&
+      (validation.owner !== undefined ? !validation.owner.error : true) &&
       taskValidJson &&
       triggerSchemaValidJson
     );
@@ -350,16 +351,16 @@ export default class HookForm extends Component {
       hook: assocPath(['metadata', 'name'], e.target.value, this.state.hook),
     });
 
-  handleOwnerChange = e =>{
+  handleOwnerChange = e => {
     this.setState({
       hook: assocPath(['metadata', 'owner'], e.target.value, this.state.hook),
-      validation:{
+      validation: {
         owner: {
           error: !e.currentTarget.validity.valid,
           message: e.currentTarget.validationMessage,
         },
       },
-    })
+    });
   };
 
   handleDescriptionChange = e =>
@@ -448,12 +449,16 @@ export default class HookForm extends Component {
           </ListItem>
           <ListItem>
             <TextField
-              error = {validation.owner.error}
+              error={
+                validation.owner !== undefined ? validation.owner.error : false
+              }
               required
               label="Owner Email"
               name="owner"
               type="email"
-              helperText={validation.owner.message}
+              helperText={
+                validation.owner !== undefined ? validation.owner.message : ''
+              }
               onChange={this.handleOwnerChange}
               fullWidth
               value={hook.metadata.owner}

--- a/src/components/HookForm/index.jsx
+++ b/src/components/HookForm/index.jsx
@@ -351,7 +351,6 @@ export default class HookForm extends Component {
     });
 
   handleOwnerChange = e =>{
-    debugger;
     this.setState({
       hook: assocPath(['metadata', 'owner'], e.target.value, this.state.hook),
       validation:{

--- a/src/components/HookForm/index.jsx
+++ b/src/components/HookForm/index.jsx
@@ -161,6 +161,7 @@ export default class HookForm extends Component {
     scheduleTextField: '',
     taskValidJson: true,
     triggerSchemaValidJson: true,
+    validation: {},
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -183,7 +184,12 @@ export default class HookForm extends Component {
       scheduleTextField: '',
       taskValidJson: true,
       triggerSchemaValidJson: true,
-      validation: {},
+      validation: {
+        owner: {
+          error: false,
+          message: '',
+        },
+      },
     };
   }
 
@@ -347,7 +353,7 @@ export default class HookForm extends Component {
       hook.hookId &&
       hook.metadata.name &&
       hook.metadata.owner &&
-      (validation.owner !== undefined ? !validation.owner.error : true) &&
+      !validation.owner.error &&
       taskValidJson &&
       triggerSchemaValidJson
     );
@@ -466,16 +472,12 @@ export default class HookForm extends Component {
           </ListItem>
           <ListItem>
             <TextField
-              error={
-                validation.owner !== undefined ? validation.owner.error : false
-              }
+              error={validation.owner.error}
               required
               label="Owner Email"
               name="owner"
               type="email"
-              helperText={
-                validation.owner !== undefined ? validation.owner.message : ''
-              }
+              helperText={validation.owner.message}
               onChange={this.handleOwnerChange}
               fullWidth
               value={hook.metadata.owner}


### PR DESCRIPTION

I modified code to use html5 input type email validation.
As the error message was not specified I added Validation message to helper text.

One thing that is strange though is that also `[a-zA-Z]+@[a-zA-Z]+` gets validated by default.
I am wondering if this is expected behaviour  of html5 input e-mail validation.

I hope I am on the right track :)
